### PR TITLE
Download entire map and image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "bootstrap": "^5.3.7",
         "chart.js": "^4.5.0",
         "chartjs-adapter-date-fns": "^3.0.0",
+        "html2canvas": "^1.4.1",
         "leaflet": "^1.9.4",
         "leaflet-draw": "^1.0.4",
         "ng2-charts": "^4.1.1",
@@ -6018,6 +6019,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -7089,6 +7099,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-loader": {
@@ -8597,6 +8616,19 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/htmlparser2": {
       "version": "10.0.0",
@@ -13620,6 +13652,15 @@
         }
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/thingies": {
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/thingies/-/thingies-1.21.0.tgz",
@@ -13972,6 +14013,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "bootstrap": "^5.3.7",
     "chart.js": "^4.5.0",
     "chartjs-adapter-date-fns": "^3.0.0",
+    "html2canvas": "^1.4.1",
     "leaflet": "^1.9.4",
     "leaflet-draw": "^1.0.4",
     "ng2-charts": "^4.1.1",

--- a/src/app/pages/map/map.component.ts
+++ b/src/app/pages/map/map.component.ts
@@ -65,21 +65,27 @@ export class MapComponent implements AfterViewInit, OnDestroy {
         attribution: 'Copernicus Data Space Ecosystem',
         version: '1.3.0',
         crs: L.CRS.EPSG3857,
+        crossOrigin: true,
       }),
       'OpenStreetMap': L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         attribution: '&copy; OpenStreetMap contributors',
+        crossOrigin: true,
       }),
       'Satellite': L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
-        attribution: 'Tiles © Esri'
+        attribution: 'Tiles © Esri',
+        crossOrigin: true,
       }),
       'Dark': L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png', {
         attribution: '&copy; CARTO',
+        crossOrigin: true,
       }),
       'Light': L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
         attribution: '&copy; CARTO',
+        crossOrigin: true,
       }),
       'Topographic': L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
         attribution: '&copy; OpenTopoMap contributors',
+        crossOrigin: true,
       }),
     };
 
@@ -255,7 +261,8 @@ export class MapComponent implements AfterViewInit, OnDestroy {
     }
 
     this.imageOverlay = L.imageOverlay(imageUrl, this.lastDrawnBounds, {
-      opacity: 1
+      opacity: 1,
+      crossOrigin: true,
     });
     this.imageOverlay.addTo(this.map);
 

--- a/src/app/sidebar/ogc-view/ogc-view.component.html
+++ b/src/app/sidebar/ogc-view/ogc-view.component.html
@@ -69,7 +69,7 @@
     </mat-select>
   </mat-form-field>
 
-  <button mat-raised-button color="accent" (click)="logWmsUrl()" style="width: 100%">
+  <button mat-raised-button color="accent" (click)="downloadMapAsImage()" style="width: 100%" [disabled]="downloading">
     Download Image
   </button>
 </div>

--- a/src/app/sidebar/ogc-view/ogc-view.component.ts
+++ b/src/app/sidebar/ogc-view/ogc-view.component.ts
@@ -15,6 +15,7 @@ import { DatePipe, NgIf, NgForOf, DecimalPipe } from '@angular/common';
 
 import { OgcService, OgcParams } from '../../services/ogc.service';
 import { GeometryService } from '../../services/geometry.service'; // ✅ Add GeometryService
+import html2canvas from 'html2canvas';
 
 @Component({
   selector: 'app-ogc-view',
@@ -129,5 +130,37 @@ export class OgcViewComponent {
     } else {
       console.warn('Unsupported format:', this.selectedFormat);
     }
+  }
+
+  downloadMapAsImage() {
+    const mapEl = document.getElementById('map');
+    if (!mapEl) {
+      this.snackBar.open('Map not found on page.', 'Close', { duration: 2500 });
+      return;
+    }
+
+    this.downloading = true;
+    html2canvas(mapEl, { useCORS: true, allowTaint: false, logging: false, scale: Math.min(2, window.devicePixelRatio || 1) })
+      .then(canvas => new Promise<Blob>((resolve, reject) => {
+        canvas.toBlob((blob) => blob ? resolve(blob) : reject(new Error('Failed to create image blob')), 'image/png');
+      }))
+      .then((blob) => {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'map.png';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+        this.snackBar.open('Map downloaded', '', { duration: 1500 });
+      })
+      .catch((err) => {
+        console.error('Map download failed:', err);
+        this.snackBar.open('Download failed. Check CORS and try again.', 'Close', { duration: 3000 });
+      })
+      .finally(() => {
+        this.downloading = false;
+      });
   }
 }


### PR DESCRIPTION
Update the 'Download Image' button to export the full rendered map as a PNG instead of just logging the WMS URL.

The previous functionality of the "Download Image" button was to log the WMS URL to the console. This PR changes its behavior to capture the entire visible Leaflet map (including base layers, WMS overlays, and any drawn features) and download it as a `map.png` file, fulfilling the user's request for a full map image download. This was achieved by integrating `html2canvas` and configuring Leaflet layers with `crossOrigin: true` to allow canvas rendering.

---
<a href="https://cursor.com/background-agent?bcId=bc-76f294aa-45c8-45c7-9421-c454f3516438">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-76f294aa-45c8-45c7-9421-c454f3516438">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

